### PR TITLE
Update default gain parameter value

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The topic can be changed via the sonar_topic parameter.
 | `fov` | `0.0872665` | FOV of the sonar transmission. Not used explicitly but put here for data |
 | `speed_of_sound` | `1500000` | Speed of sound in medium such as water in `mm/s` |
 | `auto_mode` | `true` | Whether to automatically determine gain, min, and max ranges |
-| `gain` | `0.6` | Gain of the scan when in manual mode |
+| `gain_index` | `0` | Index of the gain setting of the scan when in manual mode. Valid indices are `0-13`. Index-gain correspondences are as follows: `{0: 3.98, 1: 7.96, 2: 15.92, 3: 19.90, 4: 31.84, 5: 39.80, 6: 63.68, 7: 219.2, 8: 438.4, 9: 548.0, 10: 876.8, 11: 1096, 12: unknown, 13: unknown}`|
 | `min_range` | `0` | Min range of scan in mm when in manual mode |
 | `max_range` | `5000` | Max range of scan in mm when in manual mode |
 

--- a/s500_sonar/s500.py
+++ b/s500_sonar/s500.py
@@ -47,8 +47,8 @@ class s500_sonar:
             else:
                 if sonar.set_mode_auto(0, True):
                     sonar.set_range(params.get("min_range"), params.get("max_range"), False)
-                    sonar.set_gain_setting(params.get("gain"), False)
-                    logger.info("S500 set to manual mode with range [%f:%f]mm and gain: %f" % (params.get("min_range"), params.get("max_range"), params.get("gain")))
+                    sonar.set_gain_setting(params.get("gain_index"), False)
+                    logger.info("S500 set to manual mode with range [%f:%f]mm and gain index: %f" % (params.get("min_range"), params.get("max_range"), params.get("gain_index")))
                 else:
                     logger.warn("Unable to set manual mode on device")
             

--- a/s500_sonar/sonar_node.py
+++ b/s500_sonar/sonar_node.py
@@ -17,7 +17,7 @@ class sonar_node(Node):
             "fov": self.declare_parameter('fov', 0.0872665).value, # s500 has fov of 5 degrees or 0.0872665 rad
             "speed_of_sound": self.declare_parameter('speed_of_sound', 1500000).value, # Speed of Sound [mm/s] : Water (1500000 mm/s), Air (340000 mm/s)
             "auto_mode": self.declare_parameter('auto_mode', 'true').value, # Whether s500 automatically sets gain and scan range
-            "gain": self.declare_parameter('gain', -1).value, # Gain for s500 if auto_mode = false
+            "gain_index": self.declare_parameter('gain_index', 0).value, # Gain index for s500 if auto_mode = false, valid indices are 0-13
             "min_range": self.declare_parameter('min_range', 0).value, # Min range if auto_mode = false [mm]
             "max_range": self.declare_parameter('max_range', 5000).value, # Max range if auto_mode = false [mm]
             "comm_type": self.declare_parameter('comm_type', 'serial').value, # serial or udp

--- a/s500_sonar/sonar_node.py
+++ b/s500_sonar/sonar_node.py
@@ -17,7 +17,7 @@ class sonar_node(Node):
             "fov": self.declare_parameter('fov', 0.0872665).value, # s500 has fov of 5 degrees or 0.0872665 rad
             "speed_of_sound": self.declare_parameter('speed_of_sound', 1500000).value, # Speed of Sound [mm/s] : Water (1500000 mm/s), Air (340000 mm/s)
             "auto_mode": self.declare_parameter('auto_mode', 'true').value, # Whether s500 automatically sets gain and scan range
-            "gain": self.declare_parameter('gain', 0.6).value, # Gain for s500 if auto_mode = false
+            "gain": self.declare_parameter('gain', -1).value, # Gain for s500 if auto_mode = false
             "min_range": self.declare_parameter('min_range', 0).value, # Min range if auto_mode = false [mm]
             "max_range": self.declare_parameter('max_range', 5000).value, # Max range if auto_mode = false [mm]
             "comm_type": self.declare_parameter('comm_type', 'serial').value, # serial or udp


### PR DESCRIPTION
Updated default gain parameter value from 0.6 to -1, as the set_gain_setting() function of pinghf.py expects an integer value for the gain index, not a float value for the gain itself. Valid indices are 0-13 and -1. Setting to -1 sets the s500 to auto gain mode.